### PR TITLE
Restore support with RadioConfig@1.0 dsds clients.

### DIFF
--- a/src/java/com/android/internal/telephony/PhoneSwitcher.java
+++ b/src/java/com/android/internal/telephony/PhoneSwitcher.java
@@ -529,6 +529,7 @@ public class PhoneSwitcher extends Handler {
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED)
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_MCX)
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VCN_MANAGED)
                 .setNetworkSpecifier(new MatchAllNetworkSpecifier());
 
         NetworkFactory networkFactory = new PhoneSwitcherNetworkRequestListener(looper, context,


### PR DESCRIPTION
Add capability NET_CAPABILITY_NOT_VCN_MANAGED to the
list of "supported" capabilities on
PhoneSwitcherNetworkRequestListener.
This is used to register an offer (see superclass
NetworkFactoryImpl for details) on ConnectivityService.

When the radio turns on, the ConnectivityService is
trying to call onNetworkNeeded on them, if the offers
provide all requested capabilities.

The onNetworkNeeded() method on the
PhoneSwitcherNetworkRequestListener class is used to
set the different phones active or inactive which is
used to enable the network.

When calculating the matching offers, the ConnectivityService
prints out (with some debugging information enabled):

02-08 22:01:59.926  1676  1815 D ConnectivityService: offer.onNetworkNeeded() offer can't be satisfied offer=NetworkOffer [ Score Score(1000 ; KeepConnected : 0 ; Policies : EVER_VALIDATED&INVINCIBLE&IS_UNMETERED&IS_VALIDATED)Caps [ Tansports: CELLULAR Capabilities: MMS&SUPL&DUN&FOTA&IMS&CBS&IA&RCS&XCAP&EIMS&INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN&MCX&ENTERPRISE Specifier: <android.net.MatchAllNetworkSpecifier@0>]]
request=NetworkRequest [ REQUEST id=48, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VCN_MANAGED Uid: 10084 RequestorUid: 10084 RequestorPkg: com.android.statementservice] ]

So currently NOT_VCN_MANAGED isn't there and therefore
the phone switcher method isn't called.

Interestingly, If phone using the RadioConfig@1.1
the ril command HAL_COMMAND_PREFERRED_DATA is supported.

With that, within the onEvaluate() method activates
all phones at once, and doesn't enable them separately,
which results in an enabled data connection.

Change-Id: Ib920cbc8da35032cd659dea92de9bb5bf19dccd6