### PR TITLE
Conditionally revert "Block Binder thread until incoming call process…

### DIFF
--- a/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
+++ b/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
@@ -323,10 +323,19 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
 
         @Override
         public void onIncomingCall(IImsCallSession c, Bundle extras) {
-            // we want to ensure we block this binder thread until incoming call setup completes
-            // as to avoid race conditions where the ImsService tries to update the state of the
-            // call before the listeners have been attached.
-            executeAndWait(()-> processIncomingCall(c, extras));
+            final boolean shouldBlockBinderThreadOnIncomingCalls = SystemProperties.getBoolean(
+                    "ro.telephony.block_binder_thread_on_incoming_calls", true);
+            if (shouldBlockBinderThreadOnIncomingCalls) {
+                // we want to ensure we block this binder thread until incoming call setup completes
+                // as to avoid race conditions where the ImsService tries to update the state of the
+                // call before the listeners have been attached.
+                executeAndWait(()-> processIncomingCall(c, extras));
+            } else {
+                // for legacy IMS we want to avoid blocking the binder thread, otherwise
+                // we end up with half dead incoming calls with unattached call session
+                TelephonyUtils.runWithCleanCallingIdentity(()-> processIncomingCall(c, extras),
+                        mExecutor);
+            }
         }
 
         @Override


### PR DESCRIPTION

* Legacy IMS packages handling incoming calls in such a way that a blocked binder thread won`t allow to complete call setup, thus we have half dead incoming calls with unattached call session (caller can hear dialing tone whereas recipient got nothing)

This conditionally reverts commit 75c3dc9ba272b43971f519caba0382f9871c7d9d.

Change-Id: I55a8f3bbca4a2b9a6bc7511e9fe2d0884a8818e5